### PR TITLE
feat: expose playback state and flexible seek

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -82,7 +82,9 @@ export function useSound(soundName: SoundName, defaultOptions: SoundOptions = {}
 
         const loop = options.loop !== undefined ? options.loop : false;
         if (options.volume !== undefined) howl.volume(options.volume);
-        if (options.rate !== undefined) howl.rate(options.rate);
+        if (options.rate !== undefined) {
+          howl.rate(options.rate);
+        }
         howl.loop(loop);
 
         const id = howl.play();
@@ -162,7 +164,45 @@ export function useSound(soundName: SoundName, defaultOptions: SoundOptions = {}
     };
   }, [soundName]);
 
-  return { play, stop, pause, resume, isPlaying, isLoaded };
+  const setPlaybackRate = useCallback(
+    (rate: number) => {
+      ensureLoaded().then((howl) => {
+        howl.rate(rate);
+      });
+    },
+    [ensureLoaded]
+  );
+
+  const seek = useCallback(
+    (position: number | ((current: number) => number)) => {
+      ensureLoaded().then((howl) => {
+        const current = howl.seek() as number;
+        const newTime = typeof position === "number" ? position : position(current);
+        howl.seek(newTime);
+      });
+    },
+    [ensureLoaded]
+  );
+
+  const currentTime = useCallback(() => (soundRef.current ? (soundRef.current.seek() as number) : 0), []);
+
+  const duration = useCallback(() => (soundRef.current ? soundRef.current.duration() : 0), []);
+
+  const playbackRate = useCallback(() => (soundRef.current ? soundRef.current.rate() : 1), []);
+
+  return {
+    play,
+    stop,
+    pause,
+    resume,
+    isPlaying,
+    isLoaded,
+    currentTime,
+    duration,
+    playbackRate,
+    setPlaybackRate,
+    seek,
+  };
 }
 
 interface UseSoundOnChangeOptions extends SoundOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,4 +104,29 @@ export interface SoundHookReturn {
    * Check if the sound is loaded
    */
   isLoaded: boolean;
+
+  /**
+   * Get the current playback time in seconds
+   */
+  currentTime: () => number;
+
+  /**
+   * Get the total duration of the sound in seconds
+   */
+  duration: () => number;
+
+  /**
+   * Get the current playback rate
+   */
+  playbackRate: () => number;
+
+  /**
+   * Set playback rate
+   */
+  setPlaybackRate: (rate: number) => void;
+
+  /**
+   * Seek to a position or relative offset
+   */
+  seek: (position: number | ((current: number) => number)) => void;
 }

--- a/website/src/pages/DocumentationPage.tsx
+++ b/website/src/pages/DocumentationPage.tsx
@@ -401,6 +401,44 @@ function SoundPlayer() {
 }`}
         </CodeBlock>
 
+        <h3 className="text-xl font-semibold text-gray-700 mt-6 mb-3">Playback State & Controls</h3>
+        <p className="text-gray-600 mb-2">
+          Access playback information and control position or speed on the fly.
+        </p>
+        <CodeBlock language="tsx">
+          {`const {
+  play,
+  pause,
+  currentTime,
+  duration,
+  playbackRate,
+  setPlaybackRate,
+  seek,
+} = useSound('ambient/rain');
+
+// Seek to an absolute position
+<input
+  type="range"
+  min={0}
+  max={duration()}
+  value={currentTime()}
+  onChange={(e) => seek(Number(e.target.value))}
+/>;
+
+// Seek relative to current time
+<button onClick={() => seek((t) => t + 5)}>Skip 5s</button>;
+
+// Adjust playback rate
+<select
+  value={playbackRate()}
+  onChange={(e) => setPlaybackRate(Number(e.target.value))}
+>
+  <option value={0.5}>0.5×</option>
+  <option value={1}>1×</option>
+  <option value={1.5}>1.5×</option>
+</select>;`}
+        </CodeBlock>
+
         <h3 className="text-xl font-semibold text-gray-700 mt-6 mb-3">CLI Tool for Offline Sounds</h3>
         <p className="text-gray-600 mb-2">
           Use the CLI tool to download sounds for offline use or explore available sounds.
@@ -468,6 +506,11 @@ function PlaySounds() {
 //   resume: () => void;
 //   isPlaying: boolean;
 //   isLoaded: boolean;
+//   currentTime: () => number;
+//   duration: () => number;
+//   playbackRate: () => number;
+//   setPlaybackRate: (rate: number) => void;
+//   seek: (position: number | ((current: number) => number)) => void;
 // }`}
         </CodeBlock>
       </section>


### PR DESCRIPTION
## Summary
- derive current time, duration, and playback rate directly from Howl instead of tracking state
- expose these metrics via getter functions and support callback-based seek
- document the enhanced useSound API on the website

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: No files matching the pattern "src" were found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b8e9ddf548322b4e9eeabb06f3553